### PR TITLE
Make Authenticator available to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ func createCustomerVillage() -> VillageCustomerApiRepository {
 
     // see the docs on how we can use different token types.
     token: .stringToken(token: "abc123"),
-    repository: OpenApiCustomerApiRepositoryFactory
+    repository: OpenApiVillageCustomerApiRepository.factory
   )
 }
 ```

--- a/VillageWalletSDK.podspec
+++ b/VillageWalletSDK.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name = "VillageWalletSDK"
-  spec.version = "4.1.1"
+  spec.version = "4.2.0"
   spec.summary = "Client SDK for Village Wallet"
 
   # This description is used to generate tags and improve search results.

--- a/VillageWalletSDK/VillageCustomerApiRepository.swift
+++ b/VillageWalletSDK/VillageCustomerApiRepository.swift
@@ -25,7 +25,7 @@ public protocol VillageCustomerApiRepository {
 	var options: VillageCustomerOptions { get }
 
 	/*
-    An `ApiAuthenticator` that can be used to update the access token the SDK uses
-   */
+	 An `ApiAuthenticator` that can be used to update the access token the SDK uses
+	 */
 	var authenticator: AnyApiAuthenticator<HasAccessToken> { get }
 }

--- a/VillageWalletSDK/VillageCustomerApiRepository.swift
+++ b/VillageWalletSDK/VillageCustomerApiRepository.swift
@@ -23,4 +23,9 @@ public protocol VillageCustomerApiRepository {
 	 Options that were given at SDK initialisation
 	 */
 	var options: VillageCustomerOptions { get }
+
+	/*
+    An `ApiAuthenticator` that can be used to update the access token the SDK uses
+   */
+	var authenticator: AnyApiAuthenticator<HasAccessToken> { get }
 }

--- a/VillageWalletSDK/VillageMerchantApiRepository.swift
+++ b/VillageWalletSDK/VillageMerchantApiRepository.swift
@@ -23,4 +23,9 @@ public protocol VillageMerchantApiRepository {
 	 Options that were given at SDK initialisation
 	 */
 	var options: VillageMerchantOptions { get }
+
+	/*
+	 An `ApiAuthenticator` that can be used to update the access token the SDK uses
+	 */
+	var authenticator: AnyApiAuthenticator<HasAccessToken> { get }
 }

--- a/VillageWalletSDKTests/Podfile.lock
+++ b/VillageWalletSDKTests/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - SwiftHamcrest (2.2.1)
-  - VillageWalletSDK (4.1.1)
+  - VillageWalletSDK (4.2.0)
 
 DEPENDENCIES:
   - SwiftHamcrest (~> 2.2.1)
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   SwiftHamcrest: 67454f9c4c7fae8d7a0f82dfd42f8a54a79095b1
-  VillageWalletSDK: 699539c1cbaaf18c0aeb28662dce1c059fb286a9
+  VillageWalletSDK: 7ca3e651f94c30813ca9afab17ca20c1dfe28966
 
 PODFILE CHECKSUM: aa0efc044c3ab062130326c8b12b1d63e17a9227
 


### PR DESCRIPTION
While updating the reference app, I realised that this was a missing feature of the update to v4 of the SDK. When using non `ApiTokenType.apiAuthenticatorToken` there is currently no way to have the SDK fetch an access token.

If automatic access token renewal becomes part of the SDK, the SDK will also need to use the instance.